### PR TITLE
Refactor parsing

### DIFF
--- a/climactic/cli.py
+++ b/climactic/cli.py
@@ -56,6 +56,7 @@ parser.add_argument(
     default=["."]
 )
 
+
 parser.add_argument(
     "-v", "--verbosity",
     nargs="?",

--- a/climactic/plugins/pytest.py
+++ b/climactic/plugins/pytest.py
@@ -35,21 +35,24 @@ class ClimacticPytestPlugin:
 class ClimacticPytestFile(pytest.File):
     def collect(self):
         path = Path(str(self.fspath))
-        self.climactic_case = CliTestCase.from_path(
+        for climactic_case in CliTestCase.from_path(
             path,
             Path(str(self.parent.fspath))
-        )
-        yield ClimacticPytestItem(
-            path.parts[-1],
-            self,
-            self.climactic_case
-        )
+        ):
+            yield ClimacticPytestItem(
+                self.fspath.basename,
+                self,
+                climactic_case
+            )
 
 
 class ClimacticPytestItem(pytest.Item):
     def __init__(self, name, parent, climactic_case):
         super(ClimacticPytestItem, self).__init__(name, parent)
         self.ccase = climactic_case
+
+    def reportinfo(self):
+        return self.fspath, None, self.fspath.basename[:-4]
 
     def runtest(self):
         self.ccase.runTest()

--- a/climactic/suite.py
+++ b/climactic/suite.py
@@ -30,10 +30,10 @@ class CliTestSuite(unittest.TestSuite):
                 tests.extend(target_tests)
 
             else:
-                target_test = cls.collect_file(
+                for target_test in cls.collect_file(
                     target_path
-                )
-                tests.append(target_test)
+                ):
+                    tests.append(target_test)
         suite.addTests(tests)
         return suite
 
@@ -52,11 +52,11 @@ class CliTestSuite(unittest.TestSuite):
         )
 
         for target_path in target_paths:
-            test = cls.collect_file(
+            for test in cls.collect_file(
                 target_path,
                 base_path=dir_path
-            )
-            tests.append(test)
+            ):
+                tests.append(test)
         return tests
 
     @classmethod
@@ -65,8 +65,7 @@ class CliTestSuite(unittest.TestSuite):
             "Loading yml file %r",
             target_path
         )
-        test = CliTestCase.from_path(
+        yield from CliTestCase.from_path(
             target_path,
             base_path=base_path
         )
-        return test

--- a/examples/git/test_init.yml
+++ b/examples/git/test_init.yml
@@ -1,8 +1,9 @@
+#!yaml
 ---
 # Run `git init` and verify that the expected directory
 # structure and file contents are produced.
 
-- env:
+- !env
     CMD: git
     CMD_NAME: Git
     REPO_DIR: .git/
@@ -15,7 +16,7 @@
     Initialized empty ${CMD_NAME}
     repository in ${CWD}/${REPO_DIR}
 
-- assert-tree:
+- !assert-tree
     .git:
     - HEAD
     - objects:

--- a/examples/test_hello.yml
+++ b/examples/test_hello.yml
@@ -1,8 +1,8 @@
 ---
 # A very simple test!
 
-- run: >
+- !run >
     echo Hello world!
 
-- assert-output: >
+- !assert-output >
     Hello world!

--- a/examples/test_write.yml
+++ b/examples/test_write.yml
@@ -8,3 +8,15 @@
 
 - assert-file-utf8:
     hello.txt: Hello world!
+
+---
+# A simple test which writes to a file
+
+- !write-file-utf8
+    hello2.txt: Hello world, again!
+
+- !assert-output >
+    ""
+
+- !assert-file-utf8
+    hello2.txt: Hello world, again!


### PR DESCRIPTION
- Parse multiple documents from one YAML file
- Try to use yaml.add_constructor for each command ("!cmd" syntax), but fall back on the simplified command mapping syntax if this fails for any reason
